### PR TITLE
LIBDRUM-404 Filename not displaying in Simple Item record display

### DIFF
--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Mirage2/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Mirage2/xsl/aspect/artifactbrowser/item-view.xsl
@@ -372,7 +372,7 @@
                         </xsl:with-param>
                     </xsl:call-template>
                     <xsl:choose>
-                        <xsl:when test="contains($label-1, 'label') and mets:FLocat[@LOCTYPE='URL']/@xlink:label">
+                        <xsl:when test="contains($label-1, 'label') and mets:FLocat[@LOCTYPE='URL']/@xlink:label!=''">
                             <xsl:value-of select="mets:FLocat[@LOCTYPE='URL']/@xlink:label"/>
                         </xsl:when>
                         <xsl:when test="contains($label-1, 'title') and mets:FLocat[@LOCTYPE='URL']/@xlink:title">


### PR DESCRIPTION
Filename now displaying when description not present.

https://issues.umd.edu/browse/LIBDRUM-404