### PR TITLE
LIBDRUM-435. Update overlay classes with changes from dspace-5.4.

### DIFF
--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Mirage2/xsl/preprocess/communitylist.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Mirage2/xsl/preprocess/communitylist.xsl
@@ -236,8 +236,17 @@
         <xref target="{@OBJID}" n="community-browser-link">
             <xsl:value-of select="$dim/dim:field[@element='title']"/>
         </xref>
-            <xsl:variable name="description"
-                          select="$dim/dim:field[@element='description'][@qualifier='abstract']"/>
+        <!--Display community strengths (item counts) if they exist-->
+        <xsl:if test="string-length($dim/dim:field[@element='format'][@qualifier='extent'][1]) &gt; 0">
+            <span>
+                <xsl:text> [</xsl:text>
+                <xsl:value-of
+                    select="$dim/dim:field[@element='format'][@qualifier='extent'][1]"/>
+                <xsl:text>]</xsl:text>
+            </span>
+        </xsl:if>
+
+        <xsl:variable name="description" select="$dim/dim:field[@element='description'][@qualifier='abstract']"/>
         <xsl:if test="string-length($description/text()) > 0">
             <p rend="hidden-xs">
                 <xsl:value-of select="$description"/>


### PR DESCRIPTION
Applied change to community-browser-umd (previously applied only to community-browser-dept)

https://issues.umd.edu/browse/LIBDRUM-435