### PR TITLE
LIBDRUM-492. Match DISS_keyword node only if text non empty.

### DIFF
--- a/dspace/config/load/etd2dc.xsl
+++ b/dspace/config/load/etd2dc.xsl
@@ -72,7 +72,7 @@
      </dcvalue>
    </xsl:template>
 
-   <xsl:template match="DISS_keyword">
+   <xsl:template match="DISS_keyword[text()]">
      <xsl:call-template name="Parse_DISS_keyword">
        <xsl:with-param name="text" select="."/>
      </xsl:call-template>


### PR DESCRIPTION
https://issues.umd.edu/browse/LIBDRUM-492