### PR TITLE
LIBDRUM-566. Fix batch import issue.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
@@ -337,6 +337,7 @@ public class ItemImportServiceImpl implements ItemImportService, InitializingBea
                 }
                 Item item = addItem(c, clist, sourceDir, dircontents[i], mapOut, template);
                 c.uncacheEntity(item);
+                c.commit();
                 System.out.println(i + " " + dircontents[i]);
             }
         }


### PR DESCRIPTION
if any error occurs during a batch import, even the prior items in the batch that were loaded without error will not be commited due to transaction rollback.

This fix adds transaction commit after each item load.

https://issues.umd.edu/browse/LIBDRUM-566