### PR TITLE
LIBDRUM-578. OAI indexing fails on DRUM

### DIFF
--- a/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
@@ -311,7 +311,8 @@ public class XOAI {
         List<Date> dates = new LinkedList<Date>();
         List<ResourcePolicy> policies = authorizeService.getPoliciesActionFilter(context, item, Constants.READ);
         for (ResourcePolicy policy : policies) {
-            if (policy.getGroup().getName().equals("Anonymous")) {
+            if (policy.getGroup() != null && policy.getGroup().getName() != null
+                    && policy.getGroup().getName().equals("Anonymous")) {
                 if (policy.getStartDate() != null) {
                     dates.add(policy.getStartDate());
                 }
@@ -435,7 +436,8 @@ public class XOAI {
 
         List<ResourcePolicy> policies = authorizeService.getPoliciesActionFilter(context, item, Constants.READ);
         for (ResourcePolicy policy : policies) {
-            if (policy.getGroup().getName().equals("Anonymous")) {
+            if (policy.getGroup() != null && policy.getGroup().getName() != null
+                    && policy.getGroup().getName().equals("Anonymous")) {
                 
                 if (policy.getStartDate() != null && policy.getStartDate().after(new Date())) {
                     


### PR DESCRIPTION
DS-3969 Added check for null during indexing of OAI to avoid NullPointer

https://issues.umd.edu/browse/LIBDRUM-578