### PR TITLE
LIBDRUM-595. Skip checking DOI reservation in DataciteConnector.

### DIFF
--- a/dspace/modules/additions/src/main/java/org/dspace/identifier/DOIIdentifierProvider.java
+++ b/dspace/modules/additions/src/main/java/org/dspace/identifier/DOIIdentifierProvider.java
@@ -335,23 +335,12 @@ public class DOIIdentifierProvider
                     + "is marked as DELETED.", DOIIdentifierException.DOI_IS_DELETED);
         }
 
+        // We have to reserve DOI before we can register it
+        if (!connector.isDOIReserved(context, doi)) {
+            this.reserveOnline(context, dso, identifier);
+        }
         // register DOI Online
-        try {
-            connector.registerDOI(context, dso, doi);
-        }
-        catch (DOIIdentifierException die)
-        {
-            // do we have to reserve DOI before we can register it?
-            if (die.getCode() == DOIIdentifierException.RESERVE_FIRST)
-            {
-                this.reserveOnline(context, dso, identifier);
-                connector.registerDOI(context, dso, doi);
-            }
-            else
-            {
-                throw die;
-            }
-        }
+        connector.registerDOI(context, dso, doi);
 
         // safe DOI as metadata of the item
         try {

--- a/dspace/modules/additions/src/main/java/org/dspace/identifier/doi/DataCiteConnector.java
+++ b/dspace/modules/additions/src/main/java/org/dspace/identifier/doi/DataCiteConnector.java
@@ -509,15 +509,6 @@ implements DOIConnector
     public void registerDOI(Context context, DSpaceObject dso, String doi)
             throws DOIIdentifierException
     {
-        // DataCite wants us to reserve a DOI before we can register it
-        if (!this.isDOIReserved(context, doi))
-        {
-            // the DOIIdentifierProvider should catch and handle this
-            throw new DOIIdentifierException("You need to reserve a DOI "
-                    + "before you can register it.",
-                    DOIIdentifierException.RESERVE_FIRST);
-        }
-
         // send doi=<doi>\nurl=<url> to mds/doi
         DataCiteResponse resp = null;
         try


### PR DESCRIPTION
Notes:
    - DataCite MDS API changes (Eventual Consistency for read) is affecting the DOI regsitration.
    - Check for reserved status are returning false even though reservation has succeeded.
    - We can skip reservation status check - if we just reserved and the request succeeded.

https://issues.umd.edu/browse/LIBDRUM-595