### PR TITLE
LIBDRUM-641. Enable non-ImageMagick thumbnail filters.

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -385,6 +385,8 @@ filter.plugins = HTML Text Extractor
 filter.plugins = Word Text Extractor
 filter.plugins = Excel Text Extractor
 filter.plugins = PowerPoint Text Extractor
+filter.plugins = JPEG Thumbnail
+filter.plugins = PDFBox JPEG Thumbnail
 filter.plugins = ImageMagick Image Thumbnail
 filter.plugins = ImageMagick PDF Thumbnail
 


### PR DESCRIPTION
https://issues.umd.edu/browse/LIBDRUM-641